### PR TITLE
Updated Poco X3 ROM Data

### DIFF
--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -11,6 +11,14 @@ roms:
     rom-webpage: 'https://lineageos.org/'
     phone-webpage: 'https://wiki.lineageos.org/devices/surya/'
   - 
+    rom-name: 'ArrowOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '12L'
+    rom-notes: ''
+    rom-webpage: 'https://arrowos.net/'
+    phone-webpage: 'https://arrowos.net/download/'
+  - 
     rom-name: 'PixelExperience'
     rom-support: true
     rom-state: 'Official'
@@ -34,77 +42,13 @@ roms:
     rom-webpage: 'https://crdroid.net/'
     phone-webpage: 'https://crdroid.net/downloads#surya'
   - 
-    rom-name: 'HavocOS' #Possibly discontued
+    rom-name: 'HavocOS'
     rom-support: true
     rom-state: 'Official'
     android-version: '13' 
     rom-notes: ''
     rom-webpage: 'https://havoc-os.com/'
     phone-webpage: 'https://havoc-os.com/device#surya'
-  - 
-    rom-name: 'xiaomi.eu'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: ''
-    rom-notes: 'MIUI 14'
-    rom-webpage: 'https://xiaomi.eu/community/'
-    phone-webpage: 'https://sourceforge.net/projects/xiaomi-eu-multilang-miui-roms/files/xiaomi.eu/MIUI-STABLE-RELEASES/MIUIv14/'
-  - 
-    rom-name: 'Paranoid Android'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://paranoidandroid.co/'
-    phone-webpage: 'https://paranoidandroid.co/surya'
-  - 
-    rom-name: 'AlphaDroid'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
-    phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/surya/'
-  - 
-    rom-name: 'DerpFest'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://derpfest.org/'
-    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/surya/'
-  - 
-    rom-name: 'AncientOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://ancientrom.xyz/'
-    phone-webpage: 'https://www.pling.com/p/1998461/'
-  - 
-    rom-name: 'LibreMobileOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://libremobileos.com/'
-    phone-webpage: 'https://get.libremobileos.com/devices/surya/'
-  - 
-    rom-name: 'RisingOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://github.com/RisingTechOSS/android'
-    phone-webpage: 'https://sourceforge.net/projects/rxuglr-builds/files/surya/risingos/risingOS-v1.3-Dvaraka-RELEASE-202308142020-surya-GAPPS-OFFICIAL.zip/download'
-  - 
-    rom-name: 'ArrowOS'
-    rom-support: true
-    rom-state: 'Discontinued'
-    android-version: '12'
-    rom-notes: ''
-    rom-webpage: 'https://arrowos.net/'
-    phone-webpage: 'https://arrowos.net/download/'
   - 
     rom-name: 'PixelOS'
     rom-support: true
@@ -122,6 +66,22 @@ roms:
     rom-webpage: 'https://pixysos.com/'
     phone-webpage: 'https://pixysos.com/surya'
   - 
+    rom-name: 'xiaomi.eu'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: ''
+    rom-notes: 'MIUI 14'
+    rom-webpage: 'https://xiaomi.eu/community/'
+    phone-webpage: 'https://sourceforge.net/projects/xiaomi-eu-multilang-miui-roms/files/xiaomi.eu/MIUI-STABLE-RELEASES/MIUIv14/'
+  - 
+    rom-name: 'Paranoid Android'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://paranoidandroid.co/'
+    phone-webpage: 'https://paranoidandroid.co/surya'
+  - 
     rom-name: 'CherishOS'
     rom-support: true
     rom-state: 'Discontinued'
@@ -129,6 +89,46 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://cherishos.com/'
     phone-webpage: 'https://www.pling.com/p/1494954'
+  - 
+    rom-name: 'AlphaDroid'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
+    phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/surya/'
+  - 
+    rom-name: 'RisingOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://github.com/RisingTechOSS/android'
+    phone-webpage: 'https://sourceforge.net/projects/rxuglr-builds/files/surya/risingos/risingOS-v1.3-Dvaraka-RELEASE-202308142020-surya-GAPPS-OFFICIAL.zip/download'
+  - 
+    rom-name: 'LibreMobileOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://libremobileos.com/'
+    phone-webpage: 'https://get.libremobileos.com/devices/surya/'
+  - 
+    rom-name: 'DerpFest'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://derpfest.org/'
+    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/surya/'
+  - 
+    rom-name: 'AncientOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://ancientrom.xyz/'
+    phone-webpage: 'https://www.pling.com/p/1998461/'
   # - 
   #   rom-name: 'CorvusOS' #All links related to corvus are dead
   #   rom-support: true

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -129,14 +129,6 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://ancientrom.xyz/'
     phone-webpage: 'https://www.pling.com/p/1998461/'
-  # - 
-  #   rom-name: 'CorvusOS' #All links related to corvus are dead
-  #   rom-support: true
-  #   rom-state: 'Official'
-  #   android-version: null
-  #   rom-notes: 'Discontinued'
-  #   rom-webpage: 'https://www.corvusrom.com/'
-  #   phone-webpage: 'https://www.pling.com/p/1590082/'
 
 recoveries: null
 linux: 

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -60,7 +60,7 @@ roms:
   - 
     rom-name: 'PixysOS'
     rom-support: true
-    rom-state: 'Deprecated'
+    rom-state: 'Official'
     android-version: '11'
     rom-notes: ''
     rom-webpage: 'https://pixysos.com/'

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -45,7 +45,7 @@ roms:
     rom-name: 'HavocOS'
     rom-support: true
     rom-state: 'Official'
-    android-version: '13' 
+    android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://havoc-os.com/'
     phone-webpage: 'https://havoc-os.com/device#surya'

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -11,14 +11,6 @@ roms:
     rom-webpage: 'https://lineageos.org/'
     phone-webpage: 'https://wiki.lineageos.org/devices/surya/'
   - 
-    rom-name: 'ArrowOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '12L'
-    rom-notes: ''
-    rom-webpage: 'https://arrowos.net/'
-    phone-webpage: 'https://arrowos.net/download/'
-  - 
     rom-name: 'PixelExperience'
     rom-support: true
     rom-state: 'Official'
@@ -42,36 +34,13 @@ roms:
     rom-webpage: 'https://crdroid.net/'
     phone-webpage: 'https://crdroid.net/downloads#surya'
   - 
-    rom-name: 'CorvusOS'
+    rom-name: 'HavocOS' #Possibly discontued
     rom-support: true
     rom-state: 'Official'
-    android-version: null
-    rom-webpage: 'https://www.corvusrom.com/'
-    phone-webpage: 'https://www.pling.com/p/1590082/'
-  - 
-    rom-name: 'HavocOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
+    android-version: '13' 
     rom-notes: ''
     rom-webpage: 'https://havoc-os.com/'
     phone-webpage: 'https://havoc-os.com/device#surya'
-  - 
-    rom-name: 'PixelOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://pixelos.net/'
-    phone-webpage: 'https://pixelos.net/download/surya'
-  - 
-    rom-name: 'PixysOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '11'
-    rom-notes: ''
-    rom-webpage: 'https://pixysos.com/'
-    phone-webpage: 'https://pixysos.com/surya'
   - 
     rom-name: 'xiaomi.eu'
     rom-support: true
@@ -89,14 +58,6 @@ roms:
     rom-webpage: 'https://paranoidandroid.co/'
     phone-webpage: 'https://paranoidandroid.co/surya'
   - 
-    rom-name: 'CherishOS'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '12'
-    rom-notes: ''
-    rom-webpage: 'https://cherishos.com/'
-    phone-webpage: 'https://downloads.cherishos.com/'
-  - 
     rom-name: 'AlphaDroid'
     rom-support: true
     rom-state: 'Official'
@@ -105,13 +66,21 @@ roms:
     rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
     phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/surya/'
   - 
-    rom-name: 'RisingOS'
+    rom-name: 'DerpFest'
     rom-support: true
     rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
-    rom-webpage: 'https://github.com/RisingTechOSS/android'
-    phone-webpage: 'https://sourceforge.net/projects/rxuglr-builds/files/surya/risingos/risingOS-v1.3-Dvaraka-RELEASE-202308142020-surya-GAPPS-OFFICIAL.zip/download'
+    rom-webpage: 'https://derpfest.org/'
+    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/surya/'
+  - 
+    rom-name: 'AncientOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://ancientrom.xyz/'
+    phone-webpage: 'https://www.pling.com/p/1998461/'
   - 
     rom-name: 'LibreMobileOS'
     rom-support: true
@@ -121,21 +90,53 @@ roms:
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/surya/'
   - 
-    rom-name: 'DerpFest'
+    rom-name: 'RisingOS'
     rom-support: true
     rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
-    rom-webpage: 'https://derpfest.org/'
-    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/xiaomi/'
+    rom-webpage: 'https://github.com/RisingTechOSS/android'
+    phone-webpage: 'https://sourceforge.net/projects/rxuglr-builds/files/surya/risingos/risingOS-v1.3-Dvaraka-RELEASE-202308142020-surya-GAPPS-OFFICIAL.zip/download'
   - 
-    rom-name: 'AncientOS'
+    rom-name: 'ArrowOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '12'
+    rom-notes: 'Discontinued'
+    rom-webpage: 'https://arrowos.net/'
+    phone-webpage: 'https://arrowos.net/download/'
+  - 
+    rom-name: 'PixelOS'
     rom-support: true
     rom-state: 'Official'
     android-version: '13'
-    rom-notes: ''
-    rom-webpage: 'https://sourceforge.net/projects/ancientrom/'
-    phone-webpage: ''
+    rom-notes: 'Inactive'
+    rom-webpage: 'https://pixelos.net/'
+    phone-webpage: 'https://pixelos.net/download/surya'
+  - 
+    rom-name: 'PixysOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '11'
+    rom-notes: 'Deprecated'
+    rom-webpage: 'https://pixysos.com/'
+    phone-webpage: 'https://pixysos.com/surya'
+  - 
+    rom-name: 'CherishOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '12'
+    rom-notes: 'Discontinued'
+    rom-webpage: 'https://cherishos.com/'
+    phone-webpage: 'https://www.pling.com/p/1494954'
+  # - 
+  #   rom-name: 'CorvusOS' #All links related to corvus are dead
+  #   rom-support: true
+  #   rom-state: 'Official'
+  #   android-version: null
+  #   rom-notes: 'Discontinued'
+  #   rom-webpage: 'https://www.corvusrom.com/'
+  #   phone-webpage: 'https://www.pling.com/p/1590082/'
 
 recoveries: null
 linux: 

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -84,7 +84,7 @@ roms:
   - 
     rom-name: 'CherishOS'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '12'
     rom-notes: ''
     rom-webpage: 'https://cherishos.com/'

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -52,7 +52,7 @@ roms:
   - 
     rom-name: 'PixelOS'
     rom-support: true
-    rom-state: 'Inactive'
+    rom-state: 'Discontinued'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://pixelos.net/'

--- a/database/phone_data/xiaomi-surya.yaml
+++ b/database/phone_data/xiaomi-surya.yaml
@@ -100,33 +100,33 @@ roms:
   - 
     rom-name: 'ArrowOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '12'
-    rom-notes: 'Discontinued'
+    rom-notes: ''
     rom-webpage: 'https://arrowos.net/'
     phone-webpage: 'https://arrowos.net/download/'
   - 
     rom-name: 'PixelOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Inactive'
     android-version: '13'
-    rom-notes: 'Inactive'
+    rom-notes: ''
     rom-webpage: 'https://pixelos.net/'
     phone-webpage: 'https://pixelos.net/download/surya'
   - 
     rom-name: 'PixysOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Deprecated'
     android-version: '11'
-    rom-notes: 'Deprecated'
+    rom-notes: ''
     rom-webpage: 'https://pixysos.com/'
     phone-webpage: 'https://pixysos.com/surya'
   - 
     rom-name: 'CherishOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '12'
-    rom-notes: 'Discontinued'
+    rom-notes: ''
     rom-webpage: 'https://cherishos.com/'
     phone-webpage: 'https://www.pling.com/p/1494954'
   # - 


### PR DESCRIPTION
- Updated statuses of discontinued or inactive ROMs [Official status of ArrowOs, PixysOS, PixelOS, CherishOS is discontinued or inactive]
- Moved down discontinued ROMs in the files to keep active ROMs on top.
- Fixed rom-webpage and phone-webpage URLs for some ROMS.
- Commented out CorvusOS as all links are dead and can't find any working links for PocoX3