### PR TITLE
Poco X3 Pro (vayu): Updated ROMs data

### DIFF
--- a/database/phone_data/xiaomi-vayu.yaml
+++ b/database/phone_data/xiaomi-vayu.yaml
@@ -105,7 +105,7 @@ roms:
   - 
     rom-name: 'EvolutionX'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://evolution-x.org/'
@@ -114,14 +114,14 @@ roms:
     rom-name: 'PixelOS'
     rom-support: true
     rom-state: 'Official'
-    android-version: '14'
+    android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://pixelos.net/'
     phone-webpage: 'https://pixelos.net/download/vayu'
   - 
     rom-name: 'PixysOS'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '12'
     rom-notes: ''
     rom-webpage: 'https://pixysos.com/'
@@ -133,8 +133,8 @@ roms:
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/superioros/'
-    phone-webpage: 'https://sourceforge.net/projects/superioros/files/vayu/'
-  -
+    phone-webpage: 'https://sourceforge.net/projects/superioros/'
+  - 
     rom-name: 'xiaomi.eu'
     rom-support: true
     rom-state: 'Official'
@@ -161,7 +161,7 @@ roms:
   - 
     rom-name: 'Project Elixir'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://projectelixiros.com/home'
@@ -173,7 +173,7 @@ roms:
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://github.com/RisingTechOSS/android'
-    phone-webpage: 'https://github.com/kuroringo90/rising_builds/releases/download/v11-09-2023-1509/risingOS-v1.4-Elysium-FINAL-202309111254-vayu-GAPPS-OFFICIAL.zip'
+    phone-webpage: 'https://github.com/kuroringo90/rising_builds/releases/download/vayu-2023-04-18--01-01-57/risingOS-v1.0-Atlantis-202304171702-vayu-GAPPS-OFFICIAL.zip'
   - 
     rom-name: 'AwakenOS'
     rom-support: true
@@ -194,14 +194,14 @@ roms:
     rom-name: 'DerpFest'
     rom-support: true
     rom-state: 'Official'
-    android-version: '14'
+    android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'
-    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/vayu/'
+    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/xiaomi/'
   - 
     rom-name: 'AncientOS'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/ancientrom/'

--- a/database/phone_data/xiaomi-vayu.yaml
+++ b/database/phone_data/xiaomi-vayu.yaml
@@ -105,7 +105,7 @@ roms:
   - 
     rom-name: 'EvolutionX'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://evolution-x.org/'
@@ -114,14 +114,14 @@ roms:
     rom-name: 'PixelOS'
     rom-support: true
     rom-state: 'Official'
-    android-version: '13'
+    android-version: '14'
     rom-notes: ''
     rom-webpage: 'https://pixelos.net/'
     phone-webpage: 'https://pixelos.net/download/vayu'
   - 
     rom-name: 'PixysOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '12'
     rom-notes: ''
     rom-webpage: 'https://pixysos.com/'
@@ -133,8 +133,8 @@ roms:
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/superioros/'
-    phone-webpage: 'https://sourceforge.net/projects/superioros/'
-  - 
+    phone-webpage: 'https://sourceforge.net/projects/superioros/files/vayu/'
+  -
     rom-name: 'xiaomi.eu'
     rom-support: true
     rom-state: 'Official'
@@ -161,7 +161,7 @@ roms:
   - 
     rom-name: 'Project Elixir'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://projectelixiros.com/home'
@@ -173,7 +173,7 @@ roms:
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://github.com/RisingTechOSS/android'
-    phone-webpage: 'https://github.com/kuroringo90/rising_builds/releases/download/vayu-2023-04-18--01-01-57/risingOS-v1.0-Atlantis-202304171702-vayu-GAPPS-OFFICIAL.zip'
+    phone-webpage: 'https://github.com/kuroringo90/rising_builds/releases/download/v11-09-2023-1509/risingOS-v1.4-Elysium-FINAL-202309111254-vayu-GAPPS-OFFICIAL.zip'
   - 
     rom-name: 'AwakenOS'
     rom-support: true
@@ -194,14 +194,14 @@ roms:
     rom-name: 'DerpFest'
     rom-support: true
     rom-state: 'Official'
-    android-version: '13'
+    android-version: '14'
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'
-    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/xiaomi/'
+    phone-webpage: 'https://sourceforge.net/projects/derpfest/files/vayu/'
   - 
     rom-name: 'AncientOS'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/ancientrom/'
@@ -214,6 +214,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/vayu/'
+  -
+    rom-name: 'SkylineUI'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://github.com/SkylineUI'
+    phone-webpage: 'https://sourceforge.net/projects/skylineui/files/vayu/'
 
 recoveries: 
   - 


### PR DESCRIPTION
Discontinued:
Evolution X (September 2023 in [Support Group](https://t.me/EvolutionXVayu/256923))
PixysOS (information from Download link)
Project Elixir ([Official Telegram Channel in November 2023](https://t.me/Elixir_Updates/2919))
AncientOS (October 2023 in [Official Telegram Channel](https://t.me/ancientrom/2620))

Changed:
PixelOS + DerpFest 13 -> 14
SuperiorOS -> vayu (download link)
Fixed download link in DerpFest
Updated link for RisingOS (Latest version)

Added:
SkylineUI