### PR TITLE
Updated ROM data

### DIFF
--- a/database/phone_data/fairphone-FP4.yaml
+++ b/database/phone_data/fairphone-FP4.yaml
@@ -61,6 +61,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/FP4/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/FP4/'
 
 recoveries: null
 linux: 

--- a/database/phone_data/google-barbet.yaml
+++ b/database/phone_data/google-barbet.yaml
@@ -91,6 +91,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/barbet/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/barbet/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-bluejay.yaml
+++ b/database/phone_data/google-bluejay.yaml
@@ -107,7 +107,15 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/bluejay/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/bluejay/'
+    
 recoveries: null
 linux: 
   - 

--- a/database/phone_data/google-blueline.yaml
+++ b/database/phone_data/google-blueline.yaml
@@ -109,6 +109,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/blueline/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/blueline/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-bonito.yaml
+++ b/database/phone_data/google-bonito.yaml
@@ -100,6 +100,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/bonito/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/bonito/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-bramble.yaml
+++ b/database/phone_data/google-bramble.yaml
@@ -83,6 +83,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/bramble/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/bramble/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-cheetah.yaml
+++ b/database/phone_data/google-cheetah.yaml
@@ -139,6 +139,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://pixelos.net/'
     phone-webpage: 'https://pixelos.net/download/cheetah'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/cheetah/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-coral.yaml
+++ b/database/phone_data/google-coral.yaml
@@ -140,6 +140,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
     phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/coral/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/coral/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-crosshatch.yaml
+++ b/database/phone_data/google-crosshatch.yaml
@@ -109,6 +109,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/crosshatch/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/crosshatch/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-flame.yaml
+++ b/database/phone_data/google-flame.yaml
@@ -133,6 +133,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
     phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/flame/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/flame/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-lynx.yaml
+++ b/database/phone_data/google-lynx.yaml
@@ -100,6 +100,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/lynx/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/lynx/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-oriole.yaml
+++ b/database/phone_data/google-oriole.yaml
@@ -93,6 +93,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/oriole/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/oriole/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-panther.yaml
+++ b/database/phone_data/google-panther.yaml
@@ -139,6 +139,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
     phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/panther/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/panther/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-raven.yaml
+++ b/database/phone_data/google-raven.yaml
@@ -101,6 +101,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/raven/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/raven/'
+    
 recoveries: null
 linux: null

--- a/database/phone_data/google-redfin.yaml
+++ b/database/phone_data/google-redfin.yaml
@@ -108,7 +108,15 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/redfin/'
-
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/redfin/'
+    
 recoveries: 
   - 
     recovery-name: 'TWRP'

--- a/database/phone_data/google-sargo.yaml
+++ b/database/phone_data/google-sargo.yaml
@@ -100,6 +100,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/sargo/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/sargo/'
 
 recoveries: 
   - 

--- a/database/phone_data/google-sunfish.yaml
+++ b/database/phone_data/google-sunfish.yaml
@@ -115,6 +115,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://blissroms.org/'
     phone-webpage: 'https://downloads.blissroms.org/download/sunfish/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/sunfish/'
 
 recoveries: null
 linux: 

--- a/database/phone_data/google-tangorpro.yaml
+++ b/database/phone_data/google-tangorpro.yaml
@@ -50,6 +50,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://evolution-x.org/'
     phone-webpage: 'https://evolution-x.org/device/tangorpro'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/tangorpro/'
 
 recoveries: null
 linux: []

--- a/database/phone_data/motorola-devon.yaml
+++ b/database/phone_data/motorola-devon.yaml
@@ -85,6 +85,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'
     phone-webpage: 'https://sourceforge.net/projects/derpfest/files/devon/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/devon/'
 
 recoveries: null
 linux: null

--- a/database/phone_data/motorola-hawao.yaml
+++ b/database/phone_data/motorola-hawao.yaml
@@ -85,6 +85,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'
     phone-webpage: 'https://sourceforge.net/projects/derpfest/files/hawao/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/hawao/'
 
 recoveries: null
 linux: null

--- a/database/phone_data/motorola-rhode.yaml
+++ b/database/phone_data/motorola-rhode.yaml
@@ -127,6 +127,14 @@ roms:
     android-version: '13'
     rom-webpage: 'https://github.com/DroidX-UI'
     phone-webpage: 'https://sourceforge.net/projects/droidxui-releases/files/rhode/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/rhode/'
 
 recoveries: null
 linux: null

--- a/database/phone_data/shift-axolotl.yaml
+++ b/database/phone_data/shift-axolotl.yaml
@@ -62,6 +62,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://libremobileos.com/'
     phone-webpage: 'https://get.libremobileos.com/devices/axolotl/'
+  - 
+    rom-name: 'CalyxOS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '13'
+    rom-notes: ''
+    rom-webpage: 'https://calyxos.org/'
+    phone-webpage: 'https://calyxos.org/install/devices/axolotl/'
 
 recoveries: null
 linux: 

--- a/database/phone_data/xiaomi-onclite.yaml
+++ b/database/phone_data/xiaomi-onclite.yaml
@@ -91,7 +91,7 @@ roms:
   - 
     rom-name: 'DerpFest'
     rom-support: true
-    rom-state: 'Official'
+    rom-state: 'Discontinued'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'

--- a/database/phone_data/xiaomi-onclite.yaml
+++ b/database/phone_data/xiaomi-onclite.yaml
@@ -91,7 +91,7 @@ roms:
   - 
     rom-name: 'DerpFest'
     rom-support: true
-    rom-state: 'Discontinued'
+    rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
     rom-webpage: 'https://derpfest.org/'


### PR DESCRIPTION
- Changed Derpfest's status to discontinued for Redmi 7. On the official website, they do not list Redmi 7 as an available device anymore. On their Sourceforge page, the device did not receive any update after April.
- Added CalyxOS data to:
    -  Pixel 3-4 {Android 13)
    - Pixel 4a(5g), 5-7 and Pixel Tablet (Android 14)
    - Fairphone 4 {Android 13)
    - SHIFT6mq {Android 13)
    - Moto G32, G42, G52  {Android 13)