### PR TITLE
Update xiaomi-topaz.yaml & xiaomi-tapas.yaml

### DIFF
--- a/database/phone_data/xiaomi-tapas.yaml
+++ b/database/phone_data/xiaomi-tapas.yaml
@@ -36,6 +36,14 @@ roms:
     android-version: '14'
     rom-webpage: 'https://www.projectmatrixx.org/'
     phone-webpage: 'https://www.projectmatrixx.org/downloads/topaz'
+  - 
+    rom-name: 'Rising OS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://github.com/RisingTechOSS'
+    phone-webpage: 'https://sourceforge.net/projects/risingos-official/files/3.x/'
 
 recoveries: 
   - 

--- a/database/phone_data/xiaomi-tapas.yaml
+++ b/database/phone_data/xiaomi-tapas.yaml
@@ -29,6 +29,13 @@ roms:
     rom-notes: 'HyperOS 1.0'
     rom-webpage: 'https://xiaomi.eu/community/'
     phone-webpage: 'https://sourceforge.net/projects/xiaomi-eu-multilang-miui-roms/files/xiaomi.eu/HyperOS-STABLE-RELEASES/HyperOS1.0/'
+ - 
+    rom-name: 'Project Matrixx' 
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-webpage: 'https://www.projectmatrixx.org/'
+    phone-webpage: 'https://www.projectmatrixx.org/downloads/topaz'
 
 recoveries: 
   - 
@@ -37,5 +44,11 @@ recoveries:
     recovery-state: 'Current'
     recovery-webpage: 'https://twrp.me/'
     device-webpage: 'https://twrp.me/xiaomi/redminote12_4g.html'
+  - 
+    recovery-name: 'OrangeFox Recovery'
+    recovery-support: true
+    recovery-state: 'Current'
+    recovery-webpage: 'https://orangefox.download/'
+    device-webpage: 'https://orangefox.download/device/topaz'
 
 linux: null

--- a/database/phone_data/xiaomi-topaz.yaml
+++ b/database/phone_data/xiaomi-topaz.yaml
@@ -45,6 +45,14 @@ roms:
     rom-notes: ''
     rom-webpage: 'https://www.projectmatrixx.org/'
     phone-webpage: 'https://www.projectmatrixx.org/downloads/topaz'
+  - 
+    rom-name: 'Rising OS'
+    rom-support: true
+    rom-state: 'Official'
+    android-version: '14'
+    rom-notes: ''
+    rom-webpage: 'https://github.com/RisingTechOSS'
+    phone-webpage: 'https://sourceforge.net/projects/risingos-official/files/3.x/'
 
 recoveries: 
   - 

--- a/database/phone_data/xiaomi-topaz.yaml
+++ b/database/phone_data/xiaomi-topaz.yaml
@@ -38,14 +38,6 @@ roms:
     rom-webpage: 'https://sourceforge.net/projects/alphadroid-project/'
     phone-webpage: 'https://sourceforge.net/projects/alphadroid-project/files/topaz/'
   - 
-    rom-name: 'crDroid'
-    rom-support: true
-    rom-state: 'Official'
-    android-version: '14'
-    rom-notes: ''
-    rom-webpage: 'https://crdroid.net/'
-    phone-webpage: 'https://crdroid.net/downloads#topaz'
-  - 
     rom-name: 'Project Matrixx'
     rom-support: true
     rom-state: 'Official'


### PR DESCRIPTION
Added Project Matrixx, Rising OS and OrangeFox Recovery to Tapas.
Topaz and Tapas are the same phone, only difference is the latter has no NFC. So Topaz ROMs work for Tapas.

Added Rising OS and removed CrDroid from Topaz because maintainer got removed because of some drama.