### PR TITLE
Xiaomi Redmi Note 10 Pro (sweet) - Update Android 15 support, phone webpage link, dropped device support.

### DIFF
--- a/database/phone_data/xiaomi-sweet.yaml
+++ b/database/phone_data/xiaomi-sweet.yaml
@@ -45,7 +45,7 @@ roms:
     rom-name: 'LineageOS'
     rom-support: true
     rom-state: 'Official'
-    android-version: '14'
+    android-version: '15'
     rom-webpage: 'https://lineageos.org/'
     phone-webpage: 'https://wiki.lineageos.org/devices/sweet/'
   - 
@@ -76,7 +76,7 @@ roms:
     rom-name: 'crDroid'
     rom-support: true
     rom-state: 'Official'
-    android-version: '14'
+    android-version: '15'
     rom-notes: ''
     rom-webpage: 'https://crdroid.net/'
     phone-webpage: 'https://crdroid.net/downloads#sweet'
@@ -95,18 +95,18 @@ roms:
     android-version: '14'
     rom-notes: ''
     rom-webpage: 'https://evolution-x.org/'
-    phone-webpage: 'https://evolution-x.org/device/sweet'
+    phone-webpage: 'https://evolution-x.org/downloads/sweet'
   - 
     rom-name: 'PixelOS'
     rom-support: true
     rom-state: 'Official'
-    android-version: '14'
+    android-version: '15'
     rom-notes: ''
     rom-webpage: 'https://pixelos.net/'
     phone-webpage: 'https://pixelos.net/download/sweet'
   - 
     rom-name: 'PixysOS'
-    rom-support: true
+    rom-support: false
     rom-state: 'Official'
     android-version: '13'
     rom-notes: ''
@@ -162,7 +162,7 @@ roms:
     phone-webpage: 'https://sourceforge.net/projects/electrokernel/files/risingOS-v1.4-Elysium-FINAL-202401081020-sweet-CORE-OFFICIAL.zip/download'
   - 
     rom-name: 'DerpFest'
-    rom-support: true
+    rom-support: false
     rom-state: 'Official'
     android-version: '14'
     rom-notes: ''
@@ -210,7 +210,7 @@ roms:
     phone-webpage: 'https://awakenos.vercel.app/downloads/sweet'
   - 
     rom-name: 'Project Matrixx'
-    rom-support: true
+    rom-support: false
     rom-state: 'Official'
     android-version: '14'
     rom-notes: ''


### PR DESCRIPTION
Xiaomi Redmi Note 10 Pro (sweet)
- Update Android 15 support for LineageOS, crDroid, and PixelOS. 
- Update Evolution-X phone webpage link. 
- Set rom-support to false for PixysOS, DerpFest, and Project Matrixx